### PR TITLE
Introduce new config option TRUST_PROXY_LIST

### DIFF
--- a/pocket-id/DOCS.md
+++ b/pocket-id/DOCS.md
@@ -24,13 +24,34 @@ APP_URL: https://id.domain.com
 TRUST_PROXY: true
 ```
 
+Or, to trust only specific reverse proxies:
+
+```yaml
+APP_URL: https://id.domain.com
+TRUST_PROXY: false
+TRUST_PROXY_LIST: 10.0.0.10,10.0.1.0/24,fd00::/8
+```
+
 ### Option: `APP_URL`
 
 The `APP_URL` option sets the public-facing URL of the Pocket ID instance. This must be HTTPS and accessible by clients for authentication to work properly.
 
 ### Option: `TRUST_PROXY`
 
-If set to `true`, Pocket ID will trust proxy headers like `X-Forwarded-For`. This is useful when running behind a reverse proxy.
+Controls whether Pocket ID trusts all reverse proxies.
+
+- `false` (default): Do not trust any proxy headers.
+- `true`: Trust proxy headers from all proxies. Use this only if Pocket ID is only accessible through a trusted reverse proxy.
+
+### Option: `TRUST_PROXY_LIST`
+
+Specify a comma-separated list of trusted proxy IP addresses or CIDR ranges, for example:
+
+```text
+10.0.0.10,10.0.1.0/24,fd00::/8
+```
+
+When configured, this option takes precedence over `TRUST_PROXY` and is the recommended way to configure reverse proxies, as it limits trust to known proxy addresses.
 
 ### Option: `MAXMIND_LICENSE_KEY`
 
@@ -46,12 +67,14 @@ Optional license key for MaxMind GeoIP database integration. If provided, it ena
 ## Troubleshooting
 
 - Ensure that `APP_URL` is correctly set and accessible.
-- If using a reverse proxy, set `TRUST_PROXY` to `true` to avoid authentication issues.
+- If Pocket ID is behind a reverse proxy, either:
+  - set `TRUST_PROXY` to `true` to trust all proxies, or
+  - configure `TRUST_PROXY_LIST` with the IP addresses or CIDR ranges of your trusted reverse proxies (recommended).
 - If geolocation features are required, obtain and configure a MaxMind license key.
 
 ## More Information
 
 For additional details, visit the official Pocket ID resources:
 
-- **Website:** [Pocket ID](https://pocket-id.org/)
-- **Documentation:** [Getting Started Guide](https://pocket-id.org/docs/introduction/)
+- **Website:** https://pocket-id.org/
+- **Documentation:** https://pocket-id.org/docs/introduction/

--- a/pocket-id/config.yaml
+++ b/pocket-id/config.yaml
@@ -11,10 +11,12 @@ options:
   log_level: "info"
   APP_URL: http://localhost
   TRUST_PROXY: false
+  TRUST_PROXY_LIST: ""
 schema:
   log_level: "list(debug|info|warn|error)"
   APP_URL: str
   TRUST_PROXY: bool
+  TRUST_PROXY_LIST: str?
   MAXMIND_LICENSE_KEY: str?
 ports:
   1411/tcp: 1411

--- a/pocket-id/rootfs/etc/s6-overlay/s6-rc.d/pocket-id/run
+++ b/pocket-id/rootfs/etc/s6-overlay/s6-rc.d/pocket-id/run
@@ -17,11 +17,21 @@ fi
 
 # Set variables
 export APP_URL="$(bashio::config 'APP_URL')"
-export TRUST_PROXY="$(bashio::config 'TRUST_PROXY')"
 export ENCRYPTION_KEY_FILE="/app/data/secrets/encryption_key"
 
+# Configure trusted proxies
+if bashio::config.has_value 'TRUST_PROXY_LIST'; then
+    export TRUST_PROXY="$(bashio::config 'TRUST_PROXY_LIST')"
+    bashio::log.debug "Using TRUST_PROXY_LIST: $TRUST_PROXY"
+elif bashio::config.true 'TRUST_PROXY'; then
+    export TRUST_PROXY="true"
+    bashio::log.debug 'TRUST_PROXY enabled for all proxies'
+else
+    export TRUST_PROXY="false"
+    bashio::log.debug 'TRUST_PROXY disabled'
+fi
+
 bashio::log.debug "APP_URL value: $APP_URL"
-bashio::log.debug "TRUST_PROXY value: $TRUST_PROXY"
 
 if bashio::config.has_value 'MAXMIND_LICENSE_KEY'; then
     bashio::log.debug 'MAXMIND_LICENSE_KEY has been configured. Setting environment variable...'
@@ -30,7 +40,7 @@ else
     bashio::log.debug 'No MAXMIND_LICENSE_KEY set in configuration.'
 fi
 
-APP_LOG_LEVEL="$(bashio::string.lower "$(bashio::config 'log_level')" )"
+APP_LOG_LEVEL="$(bashio::string.lower "$(bashio::config 'log_level')")"
 export LOG_LEVEL="${APP_LOG_LEVEL}"
 
 # Run pocket-id


### PR DESCRIPTION
Introduce a new option TRUST_PROXY_LIST which allows to overwrite TRUST_PROXY and utilize the possibility to set proxy IPs, as introduced in pocket-id v2.11.0